### PR TITLE
Report error messages for all unmatched templates.

### DIFF
--- a/srcgen/Makefile
+++ b/srcgen/Makefile
@@ -296,6 +296,7 @@ SOURCES := \
   pats_typerase_decl.dats \
   pats_ccomp.sats \
   pats_ccomp.dats \
+  pats_ccomp_error.dats \
   pats_ccomp_print.dats \
   pats_ccomp_hitype.dats \
   pats_ccomp_tmplab.dats \
@@ -542,6 +543,7 @@ TARGETS := \
   pats_typerase_decl_dats.c \
   pats_ccomp_sats.c \
   pats_ccomp_dats.c \
+  pats_ccomp_error_dats.c \
   pats_ccomp_print_dats.c \
   pats_ccomp_hitype_dats.c \
   pats_ccomp_tmplab_dats.c \
@@ -787,6 +789,7 @@ OBJECTS := \
   pats_typerase_decl_dats.o \
   pats_ccomp_sats.o \
   pats_ccomp_dats.o \
+  pats_ccomp_error_dats.o \
   pats_ccomp_print_dats.o \
   pats_ccomp_hitype_dats.o \
   pats_ccomp_tmplab_dats.o \
@@ -1509,6 +1512,9 @@ pats_ccomp_sats.o: pats_ccomp_sats.c; $(ATSCC) $(CFLAGS) -c $<
 
 pats_ccomp_dats.c: pats_ccomp.dats; $(ATSCC) $(DATSCC) -cc $<
 pats_ccomp_dats.o: pats_ccomp_dats.c; $(ATSCC) $(CFLAGS) -c $<
+
+pats_ccomp_error_dats.c: pats_ccomp_error.dats; $(ATSCC) $(DATSCC) -cc $<
+pats_ccomp_error_dats.o: pats_ccomp_error_dats.c; $(ATSCC) $(CFLAGS) -c $<
 
 pats_ccomp_print_dats.c: pats_ccomp_print.dats; $(ATSCC) $(DATSCC) -cc $<
 pats_ccomp_print_dats.o: pats_ccomp_print_dats.c; $(ATSCC) $(CFLAGS) -c $<

--- a/srcgen/pats_ccomp.sats
+++ b/srcgen/pats_ccomp.sats
@@ -2517,4 +2517,16 @@ fun ccomp_main
 
 (* ****** ****** *)
 
+//
+// RK-2019-05-13
+// 
+datatype ccomperr =
+  | CCE_template_noimpl of (loc_t, d2cst, t2mpmarglst)
+// end of [ccomperr]
+
+fun the_ccomperrlst_add (x: ccomperr): void
+fun the_ccomperrlst_finalize (): void // cleanup all the errors
+
+(* ****** ****** *)
+
 (* end of [pats_ccomp.sats] *)

--- a/srcgen/pats_ccomp_error.dats
+++ b/srcgen/pats_ccomp_error.dats
@@ -1,0 +1,77 @@
+//
+// RK-2019-05-13:
+// Followed the format of ./pats_trans3_error.dats
+// and added relevant definitions to ./pats_ccomp.dats
+//
+staload
+ATSPRE = "./pats_atspre.dats"
+//
+(* ****** ****** *)
+
+staload ERR = "./pats_error.sats"
+
+(* ****** ****** *)
+
+staload "./pats_ccomp.sats"
+
+(* ****** ****** *)
+//
+vtypedef
+ccomperrlst_vt = List_vt (ccomperr)
+//
+(* ****** ****** *)
+
+local
+
+val
+the_ccomperrlst = ref<ccomperrlst_vt> (list_vt_nil)
+
+fun
+the_ccomperrlst_get
+(
+// argumentless
+) : ccomperrlst_vt = let
+  val (vbox pf | p) = ref_get_view_ptr (the_ccomperrlst)
+  val xs = !p
+  val () = !p := list_vt_nil ()
+in
+  xs
+end // end of [the_ccomperrlst_get]
+
+in (* in-of-local *)
+
+implement
+the_ccomperrlst_add
+  (x) = () where {
+  val (vbox pf | p) = ref_get_view_ptr (the_ccomperrlst)
+  val () = !p := list_vt_cons (x, !p)
+} // end of [the_ccomperrlst_add]
+
+implement
+the_ccomperrlst_finalize () = {
+  val xs =
+    the_ccomperrlst_get ()
+  // end of [val]
+  val nxs = list_vt_length (xs)
+  val ((*freed*)) = list_vt_free (xs)
+// (*
+  val () =
+  if nxs > 0 then {
+    val () =
+    fprintf (
+      stderr_ref
+    , "patsopt(CCOMP): there are [%i] errors in total.\n", @(nxs)
+    ) (* end of [fprintf] *)
+  } (* end of [if] *) // end of [val]
+// *)
+  val () =
+  if nxs > 0
+    then $raise($ERR.PATSOPT_CCOMP_EXN())
+  // end of [if]
+} (* end of [the_ccomperrlst_finalize] *)
+
+end // end of [local]
+
+(* ****** ****** *)
+
+(* end of [pats_ccomp_error.dats] *)

--- a/srcgen/pats_ccomp_main.dats
+++ b/srcgen/pats_ccomp_main.dats
@@ -1448,10 +1448,16 @@ val () = the_funlablst_initset2()
 //
 } (* end of [val] *)
 //
+(* 
+//
+// RK 2019-05-13
+// original location moved below
+//
 val () = emit_time_stamp(out)
 //
 val () = emit_ats_ccomp_header(out)
 val () = emit_ats_ccomp_prelude(out)
+*)
 //
 val () = let
   val pmds = hideclist_ccomp0(hids)
@@ -1467,6 +1473,18 @@ val () = let
 in
   // nothing
 end // end of [val]
+//
+// RK : 2019-05-13
+// check that templates have implementations...
+//
+val () = the_ccomperrlst_finalize((*void*))
+//
+// RK : 2019-05-13
+// moved to here
+val () = emit_time_stamp(out)
+val () = emit_ats_ccomp_header(out)
+val () = emit_ats_ccomp_prelude(out)
+//
 //
 #if(0)
 val () = emit_the_tmpdeclst(out)

--- a/srcgen/pats_ccomp_template.dats
+++ b/srcgen/pats_ccomp_template.dats
@@ -1343,8 +1343,31 @@ case+ mat of
 | TMPCSTMATsome2
     (d2c, s2ess, flab) =>
     primval_make2_funlab(loc0, hse0, flab)
-| TMPCSTMATnone() =>
-    primval_tmpltcstmat(loc0, hse0, d2c, t2mas, mat)
+| TMPCSTMATnone () => 
+  //
+  // RK-2019-05-13:
+  // If we have traveled this far, 
+  //   there does not exist a template match 
+  //   for the given template arguments. 
+  // As a result, ouput error message and
+  //   add error to ccomp error list
+  // 
+  primval_tmpltcstmat
+    (loc0, hse0, d2c, t2mas, mat) where
+  {
+    macdef prtmperr (x) = fprint(stderr_ref, ,(x))
+    val () = (
+      emit_location(stderr_ref, loc0);
+      //fprint_tmpcstmat(stdout_ref, mat); 
+      prtmperr(": warning(template): template instance not found: ");
+      fprint_d2cst(stderr_ref, d2c);
+      prtmperr("<");
+      fpprint_t2mpmarglst(stderr_ref, t2mas);
+      prtmperr("\n")
+    )
+    val () = 
+    the_ccomperrlst_add (CCE_template_noimpl(loc0, d2c, t2mas))
+  }
   // end of [TMPCSTMATnone]
 //
 end // end of [ccomp_tmpcstmat]

--- a/srcgen/pats_error.sats
+++ b/srcgen/pats_error.sats
@@ -68,6 +68,12 @@ exception PATSOPT_TRANS4_EXN of ()
 (*
 exception PATSOPT_TYPERASE_EXN of ()
 *)
+// 
+// RK-2019-05-13:
+// adding exception for templates
+// without implementations
+//
+exception PATSOPT_CCOMP_EXN of ()
 //
 (* ****** ****** *)
 

--- a/srcgen/pats_main.dats
+++ b/srcgen/pats_main.dats
@@ -387,6 +387,7 @@ dynload "pats_typerase_dynexp.dats"
 dynload "pats_typerase_decl.dats"
 //
 dynload "pats_ccomp.dats"
+dynload "pats_ccomp_error.dats"
 dynload "pats_ccomp_print.dats"
 //
 dynload "pats_ccomp_hitype.dats"


### PR DESCRIPTION
Just a possibility...

If there are reasons against doing so? Or perhaps, something I have overlooked i.e. targeting c++ templates, etc.

At the very least, we can output some warning message at this location, [here](https://github.com/sparverius/ATS-Temptory/blob/4db5f8c7ec8f16bbffec9fa47e76a354696f5d22/srcgen/pats_ccomp_template.dats#L1358-L1367)

The nice thing about throwing an exception is that we will not waste time emitting code when we know that the emitted code will throw error(s) from gcc or the like.

The only thing remaining is to remove the file that was opened earlier in ccomp phase in the event that this exception gets thrown.
