### PR TITLE
ATS_FREE -> ATS_MFREE

### DIFF
--- a/libats/CATS/basics_string.cats
+++ b/libats/CATS/basics_string.cats
@@ -38,7 +38,7 @@
 /* ****** ****** */
 //
 #define \
-temptory_string0_vt_free(cs) ATS_FREE(cs)
+temptory_string0_vt_free(cs) ATS_MFREE(cs)
 //
 /* ****** ****** */
 

--- a/libats/DATS/unsafe.dats
+++ b/libats/DATS/unsafe.dats
@@ -105,7 +105,7 @@ cptr0_set(cp, x0) = ptr0_set<a>(cptr2ptr(cp), x0)
 implement
 {}(*tmp*)
 cfree{a}(cp0) =
-$extfcall(void, "ATS_FREE", cp0)
+$extfcall(void, "ATS_MFREE", cp0)
 //
 implement
 {a}(*tmp*)


### PR DESCRIPTION
ATS_FREE is not in the runtime for ATS-TEMPTORY so, these calls should be to ATS_MFREE instead.