### PR TITLE
additions for exceptions

### DIFF
--- a/libats/CATS/basics.cats
+++ b/libats/CATS/basics.cats
@@ -191,11 +191,12 @@ atspre_argv_set_at
 /* ****** ****** */
 
 #include "libats/CATS/basics_unsafe.cats"
-    
+
 /* ****** ****** */
 
 #if(0)
 ATSdynexn_dec(temptory_056___ListSubscriptExn) ;
+ATSdynexn_dec(temptory_056___StreamSubscriptExn) ;
 ATSdynexn_dec(temptory_056___ArraySubscriptExn) ;
 #endif // #if(0)
 

--- a/libats/SATS/stream.sats
+++ b/libats/SATS/stream.sats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -37,6 +37,11 @@
 ATS_PACKNAME "temptory."
 #define
 ATS_EXTERN_PREFIX "temptory_"
+
+(* ****** ****** *)
+
+exception
+StreamSubscriptExn of ()
 
 (* ****** ****** *)
 //

--- a/libats/SATS/stream_vt.sats
+++ b/libats/SATS/stream_vt.sats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -37,6 +37,11 @@
 ATS_PACKNAME "temptory."
 #define
 ATS_EXTERN_PREFIX "temptory_"
+
+(* ****** ****** *)
+
+exception
+StreamSubscriptExn of ()
 
 (* ****** ****** *)
 //


### PR DESCRIPTION
What is the plan for exceptions in Temptory? I noticed in [the Game-of-24 example here](https://github.com/githwxi/ATS-Temptory/blob/master/docgen/CodeBook/RECIPE/Game-of-24/Game-of-24.dats#L243-L251) that exceptions were embedded within a C block. Also, in [libats/CATS/basics.cats](https://github.com/githwxi/ATS-Temptory/blob/master/libats/CATS/basics.cats#L197-L200) they exist as dead code. One function I can think of that would use such an exception are 'nth' operations. For example,

```ats
fun{a:tflt} stream_vt_nth_exn (xs0: stream_vt a, i: Intgte(0)) : a = let
  val xs0_con = !xs0
in
//
case+ xs0_con of
| ~(stream_vt_cons(x, xs)) =>
(
if i = 0 then (~xs; x) else stream_vt_nth_exn<a> (xs, i-1)
)
| ~stream_vt_nil() => $raise(StreamSubscriptExn())
end

```
