### PR TITLE
Report error messages for all unmatched templates.(2)

### DIFF
--- a/srcgen/Makefile
+++ b/srcgen/Makefile
@@ -63,7 +63,7 @@ LIBATS=-lats
 
 ######
 #
-# HX: no [gmp] 
+# HX: no [gmp]
 ifeq ($(C3NSTRINTKND),intknd)
 LIBGMP=
 endif
@@ -304,6 +304,7 @@ SOURCES := \
   pats_typerase_decl.dats \
   pats_ccomp.sats \
   pats_ccomp.dats \
+  pats_ccomp_error.dats \
   pats_ccomp_print.dats \
   pats_ccomp_hitype.dats \
   pats_ccomp_tmplab.dats \
@@ -550,6 +551,7 @@ BUILD/pats_typerase_dynexp_dats.c \
 BUILD/pats_typerase_decl_dats.c \
 BUILD/pats_ccomp_sats.c \
 BUILD/pats_ccomp_dats.c \
+BUILD/pats_ccomp_error_dats.c \
 BUILD/pats_ccomp_print_dats.c \
 BUILD/pats_ccomp_hitype_dats.c \
 BUILD/pats_ccomp_tmplab_dats.c \
@@ -795,6 +797,7 @@ BUILD/pats_typerase_dynexp_dats.o \
 BUILD/pats_typerase_decl_dats.o \
 BUILD/pats_ccomp_sats.o \
 BUILD/pats_ccomp_dats.o \
+BUILD/pats_ccomp_error_dats.o \
 BUILD/pats_ccomp_print_dats.o \
 BUILD/pats_ccomp_hitype_dats.o \
 BUILD/pats_ccomp_tmplab_dats.o \
@@ -1518,6 +1521,11 @@ BUILD/pats_ccomp_sats.o: BUILD/pats_ccomp_sats.c; $(ATS1CC) $(CFLAGS) -c -o $@ $
 BUILD/pats_ccomp_dats.c: pats_ccomp.dats; $(ATSOPT) $(DATSCC) -o $@ -d $<
 BUILD/pats_ccomp_dats.o: BUILD/pats_ccomp_dats.c; $(ATS1CC) $(CFLAGS) -c -o $@ $<
 
+# RK
+BUILD/pats_ccomp_error_dats.c: pats_ccomp_error.dats; $(ATSOPT) $(DATSCC) -o $@ -d $<
+BUILD/pats_ccomp_error_dats.o: BUILD/pats_ccomp_error_dats.c; $(ATS1CC) $(CFLAGS) -c -o $@ $<
+#
+
 BUILD/pats_ccomp_print_dats.c: pats_ccomp_print.dats; $(ATSOPT) $(DATSCC) -o $@ -d $<
 BUILD/pats_ccomp_print_dats.o: BUILD/pats_ccomp_print_dats.c; $(ATS1CC) $(CFLAGS) -c -o $@ $<
 
@@ -1626,7 +1634,7 @@ clean:: ; $(RMF) $(DIR)/*~
 clean:: ; $(RMF) $(DIR)/*_?ats.c
 clean:: ; $(RMF) $(DIR)/BUILD/*_?ats.o
 clean:: ; $(RMF) $(DIR)/BUILD/*_?ats.c
-clean:: ; $(RMF) $(DIR)/BUILD/pats_*.cats 
+clean:: ; $(RMF) $(DIR)/BUILD/pats_*.cats
 
 cleanall:: clean
 cleanall:: ; $(RMF) TAGATS

--- a/srcgen/Makefile_CBOOTgmp
+++ b/srcgen/Makefile_CBOOTgmp
@@ -300,6 +300,7 @@ SOURCES := \
   pats_ccomp_decl.dats \
   pats_ccomp_subst.dats \
   pats_ccomp_environ.dats \
+  pats_ccomp_error.dats \
   pats_ccomp_template.dats \
   pats_ccomp_emit.dats \
   pats_ccomp_emit2.dats \

--- a/srcgen/Makefile_CBOOTint
+++ b/srcgen/Makefile_CBOOTint
@@ -303,6 +303,7 @@ SOURCES := \
   pats_ccomp_decl.dats \
   pats_ccomp_subst.dats \
   pats_ccomp_environ.dats \
+  pats_ccomp_error.dats \
   pats_ccomp_template.dats \
   pats_ccomp_emit.dats \
   pats_ccomp_emit2.dats \

--- a/srcgen/pats_ccomp.sats
+++ b/srcgen/pats_ccomp.sats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -79,7 +79,7 @@ staload "./pats_staexp2.sats"
 staload
 S2EUT =
 "./pats_staexp2_util.sats"
-vtypedef stasub = $S2EUT.stasub 
+vtypedef stasub = $S2EUT.stasub
 //
 (* ****** ****** *)
 
@@ -484,7 +484,7 @@ datatype tmpsub =
   | TMPSUBcons of (s2var, s2exp, tmpsub) | TMPSUBnil of ()
 typedef tmpsubopt = Option (tmpsub)
 vtypedef tmpsubopt_vt = Option_vt (tmpsub)
- 
+
 fun fprint_tmpsub : fprint_type (tmpsub)
 fun fprint_tmpsubopt : fprint_type (tmpsubopt)
 
@@ -548,7 +548,7 @@ fun fprint_primcstsp : fprint_type (primcstsp)
 datatype
 primdec_node =
 //
-  | PMDnone of () 
+  | PMDnone of ()
   | PMDlist of (primdeclst)
 //
   | PMDsaspdec of (s2aspdec)
@@ -654,7 +654,7 @@ and primval_node =
       (d2var, t2mpmarglst) // for template variables
     // end of [PMVtmpltvar]
 //
-  | PMVtmpltcstmat of  // for matched 
+  | PMVtmpltcstmat of  // for matched
       (d2cst, t2mpmarglst, tmpcstmat) // template constants
     // end of [PMVtmpltcstmat]
   | PMVtmpltvarmat of //  for matched
@@ -1215,7 +1215,7 @@ instr_node =
 //
   | INSextfcall of (tmpvar, string(*fun*), primvalist(*arg*))
   | INSextmcall of (tmpvar, primval(*obj*), string(*mtd*), primvalist(*arg*))
-//    
+//
   | INScond of ( // conditinal instruction
       primval(*test*), instrlst(*then*), instrlst(*else*)
     ) // end of [INScond]
@@ -1482,7 +1482,7 @@ fun instr_patck
 (
   loc: loc_t, pmv: primval, ptck: patck, ptknt: patckont
 ) : instr // pattern check
-  
+
 (* ****** ****** *)
 
 fun
@@ -1922,7 +1922,7 @@ fun ccompenv_localjoin
 fun ccompenv_add_vbindmapall
   (env: !ccompenv, d2v: d2var, pmv: primval): void
 // end of [ccompenv_add_vbindmapall]
-  
+
 fun ccompenv_find_vbindmapall
   (env: !ccompenv, d2v: d2var): Option_vt (primval)
 // end of [ccompenv_find_vbindmapall]
@@ -2022,7 +2022,7 @@ fun hidexp_ccomp_fix : hidexp_ccomp_funtype
 fun hidexp_ccomp_loop : hidexp_ccomp_funtype
 fun hidexp_ccomp_loopexn : hidexp_ccomp_funtype
 //
-fun hidexp_ccompv : hidexp_ccomp_funtype  
+fun hidexp_ccompv : hidexp_ccomp_funtype
 //
 (* ****** ****** *)
 
@@ -2514,6 +2514,18 @@ fun ccomp_main
 (
   out: FILEref, flag: int, infil: filename, hids: hideclist
 ) : void // end of [ccomp_main]
+
+(* ****** ****** *)
+
+//
+// RK-2019-05-13
+//
+datatype ccomperr =
+  | CCE_template_noimpl of (loc_t, d2cst, t2mpmarglst)
+// end of [ccomperr]
+
+fun the_ccomperrlst_add (x: ccomperr): void
+fun the_ccomperrlst_finalize (): void // cleanup all the errors
 
 (* ****** ****** *)
 

--- a/srcgen/pats_ccomp_error.dats
+++ b/srcgen/pats_ccomp_error.dats
@@ -1,0 +1,77 @@
+//
+// RK-2019-05-13:
+// Followed the format of ./pats_trans3_error.dats
+// and added relevant definitions to ./pats_ccomp.dats
+//
+staload
+ATSPRE = "./pats_atspre.dats"
+//
+(* ****** ****** *)
+
+staload ERR = "./pats_error.sats"
+
+(* ****** ****** *)
+
+staload "./pats_ccomp.sats"
+
+(* ****** ****** *)
+//
+vtypedef
+ccomperrlst_vt = List_vt (ccomperr)
+//
+(* ****** ****** *)
+
+local
+
+val
+the_ccomperrlst = ref<ccomperrlst_vt> (list_vt_nil)
+
+fun
+the_ccomperrlst_get
+(
+// argumentless
+) : ccomperrlst_vt = let
+  val (vbox pf | p) = ref_get_view_ptr (the_ccomperrlst)
+  val xs = !p
+  val () = !p := list_vt_nil ()
+in
+  xs
+end // end of [the_ccomperrlst_get]
+
+in (* in-of-local *)
+
+implement
+the_ccomperrlst_add
+  (x) = () where {
+  val (vbox pf | p) = ref_get_view_ptr (the_ccomperrlst)
+  val () = !p := list_vt_cons (x, !p)
+} // end of [the_ccomperrlst_add]
+
+implement
+the_ccomperrlst_finalize () = {
+  val xs =
+    the_ccomperrlst_get ()
+  // end of [val]
+  val nxs = list_vt_length (xs)
+  val ((*freed*)) = list_vt_free (xs)
+// (*
+  val () =
+  if nxs > 0 then {
+    val () =
+    fprintf (
+      stderr_ref
+    , "patsopt(CCOMP): there are [%i] errors in total.\n", @(nxs)
+    ) (* end of [fprintf] *)
+  } (* end of [if] *) // end of [val]
+// *)
+  val () =
+  if nxs > 0
+    then $raise($ERR.PATSOPT_CCOMP_EXN())
+  // end of [if]
+} (* end of [the_ccomperrlst_finalize] *)
+
+end // end of [local]
+
+(* ****** ****** *)
+
+(* end of [pats_ccomp_error.dats] *)

--- a/srcgen/pats_ccomp_main.dats
+++ b/srcgen/pats_ccomp_main.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -773,7 +773,7 @@ case+ fls of
         // end of [if]
     ) : void // end of [val]
   in
-    loop(fls)        
+    loop(fls)
   end // end of [list_cons]
 //
 end // end of [loop]
@@ -1448,10 +1448,17 @@ val () = the_funlablst_initset2()
 //
 } (* end of [val] *)
 //
+//
+(*
+//
+// RK 2019-05-13
+// original location moved below
+//
 val () = emit_time_stamp(out)
 //
 val () = emit_ats_ccomp_header(out)
 val () = emit_ats_ccomp_prelude(out)
+*)
 //
 val () = let
   val pmds = hideclist_ccomp0(hids)
@@ -1467,6 +1474,19 @@ val () = let
 in
   // nothing
 end // end of [val]
+//
+// RK : 2019-05-13
+// check that templates have implementations...
+//
+val () = the_ccomperrlst_finalize((*void*))
+//
+// RK : 2019-05-13
+// moved to here
+val () = emit_time_stamp(out)
+val () = emit_ats_ccomp_header(out)
+val () = emit_ats_ccomp_prelude(out)
+//
+//
 //
 #if(0)
 val () = emit_the_tmpdeclst(out)

--- a/srcgen/pats_ccomp_template.dats
+++ b/srcgen/pats_ccomp_template.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -1343,8 +1343,35 @@ case+ mat of
 | TMPCSTMATsome2
     (d2c, s2ess, flab) =>
     primval_make2_funlab(loc0, hse0, flab)
+(* RK
 | TMPCSTMATnone() =>
     primval_tmpltcstmat(loc0, hse0, d2c, t2mas, mat)
+*)
+| TMPCSTMATnone() =>
+  //
+  // RK-2019-05-13:
+  // If we have traveled this far,
+  //   there does not exist a template match
+  //   for the given template arguments.
+  // As a result, ouput error message and
+  //   add error to ccomp error list
+  //
+  primval_tmpltcstmat
+    (loc0, hse0, d2c, t2mas, mat) where
+  {
+    macdef prtmperr (x) = fprint(stderr_ref, ,(x))
+    val () = (
+      emit_location(stderr_ref, loc0);
+      //fprint_tmpcstmat(stdout_ref, mat);
+      prtmperr(": warning(template): template instance not found: ");
+      fprint_d2cst(stderr_ref, d2c);
+      prtmperr("<");
+      fpprint_t2mpmarglst(stderr_ref, t2mas);
+      prtmperr("\n")
+    )
+    val () =
+    the_ccomperrlst_add (CCE_template_noimpl(loc0, d2c, t2mas))
+  }
   // end of [TMPCSTMATnone]
 //
 end // end of [ccomp_tmpcstmat]

--- a/srcgen/pats_error.sats
+++ b/srcgen/pats_error.sats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -68,6 +68,12 @@ exception PATSOPT_TRANS4_EXN of ()
 (*
 exception PATSOPT_TYPERASE_EXN of ()
 *)
+//
+// RK-2019-05-13:
+// adding exception for templates
+// without implementations
+//
+exception PATSOPT_CCOMP_EXN of ()
 //
 (* ****** ****** *)
 

--- a/srcgen/pats_main.dats
+++ b/srcgen/pats_main.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -387,6 +387,10 @@ dynload "pats_typerase_dynexp.dats"
 dynload "pats_typerase_decl.dats"
 //
 dynload "pats_ccomp.dats"
+
+// RK
+dynload "pats_ccomp_error.dats"
+
 dynload "pats_ccomp_print.dats"
 //
 dynload "pats_ccomp_hitype.dats"
@@ -893,7 +897,7 @@ val fullname = string_of_strptr(fullname)
 val filename =
   $FIL.filename_make(given, given, fullname)
 //
-val (pfpush|()) = 
+val (pfpush|()) =
   $FIL.the_filenamelst_push(filename)
 val d0cs =
   parse_from_filename_toplevel(0(*sta*), filename)
@@ -1372,7 +1376,7 @@ val ((*void*)) = print_newline((*void*))
 } (* end of [val] *)
 *)
 //
-val () = 
+val () =
 {
 //
 val flag =
@@ -1448,11 +1452,11 @@ do_transfinal
   (state, given, d0cs) = let
 //
 (*
-val () = 
+val () =
 println!
 ("PACKNAME=",
  $GLOB.the_PACKNAME_get())
-val () = 
+val () =
 println!
 ("STATIC_PREFIX=",
  $GLOB.the_STATIC_PREFIX_get())
@@ -1582,7 +1586,7 @@ case+ exn of
 (*
 | $ERR.PATSOPT_FILENONE_EXN(fname) =>
   (
-    fold@(exn);  
+    fold@(exn);
     fprintf (outfil, "/* ****** ****** */\n//\n", @());
     fprintf (outfil, "#error(patsopt(%s): [%s] cannot be accessed)\n", @(given, fname));
     fprintf (outfil, "//\n/* ****** ****** */\n", @());
@@ -2156,7 +2160,7 @@ tempopt_main
 //
 val () =
 set () where
-{ 
+{
   extern
   fun set(): void
     = "mac#patsopt_PATSHOME_set"
@@ -2173,7 +2177,7 @@ set () where
 //
 val () =
 set () where
-{ 
+{
   extern
   fun set(): void
     = "mac#patsopt_PATSRELOCROOT_set"
@@ -2182,7 +2186,7 @@ set () where
 //
 val () =
 set () where
-{ 
+{
   extern
   fun set(): void
     = "mac#patsopt_PATSHOMELOCS_set"
@@ -2262,7 +2266,7 @@ state = @{
 , atsreloc= 0 // for package relocation
 //
 , codegenflag= 0 // syntax level for CODEgen
-, jsonizeflag= 0 // syntax level for JSONize 
+, jsonizeflag= 0 // syntax level for JSONize
 //
 , typecheckflag= 0 // compiling by default
 //


### PR DESCRIPTION
See #1 

#### Example to show desired output 

```ats
#include "share/HATS/temptory_staload_bucs320.hats"
abstbox foo = ptr
implfun main0() = print$val<foo>(_)
```

#### Error message reported
```
Temptory/libats/DATS/print.dats: 60:1-14

60| fprint$val<a>(the_stdout<>(), x)
    ^^^^^^^^^^^^^ 
   error:  template instance not found: fprint$val<S2Ecst(foo)>

patsopt(CCOMP): there are [1] errors in total.
     exit(ATS): (1033)
```