### PR TITLE
Suppress location printing when no code is emitted.

### DIFF
--- a/srcgen/pats_ccomp_emit3.dats
+++ b/srcgen/pats_ccomp_emit3.dats
@@ -306,8 +306,6 @@ case+ d2cs of
         idopt
       , fil, flag, fenv, _(*loaded*)
       ) => let
-        val () =
-          auxloc(out, d2c.d2ecl_loc)
         val d2cs =
           $TR2ENV.filenv_get_d2eclist(fenv)
         val issta =
@@ -369,8 +367,6 @@ case+ d2cs of
         idopt
       , fil, flag, fenv, loaded
       ) => let
-        val () =
-          auxloc(out, d2c.d2ecl_loc)
         val d2cs =
           $TR2ENV.filenv_get_d2eclist(fenv)
         val issta =


### PR DESCRIPTION
This is really minor: it supresses some locations being printed as comments in the beginning of the generated files.

As I see it, the only branches leading to actual code being emitted already do the location printing, so these two are extraneous. I got tired of paging through the location info comments while inspecting the C code generated for `docgen/UNSORTED/CODE`.