### PR TITLE
migrating tempacc to compilation by tempopt

### DIFF
--- a/libats/CATS/basics.cats
+++ b/libats/CATS/basics.cats
@@ -105,6 +105,8 @@ void
 atspre_exit
 (atstype_int ecd){ exit(ecd); return; }
 
+#define atspre_exit_void atspre_exit
+
 /* ****** ****** */
 
 ATSinline()

--- a/libats/DATS/gseq_string.dats
+++ b/libats/DATS/gseq_string.dats
@@ -186,4 +186,18 @@ gseq_foldright$fopr<gseq><cs,c0><r0>(c0, r0) = string0_foldright$fopr<r0>(c0, r0
 
 (* ****** ****** *)
 
+impltmp
+{r0}(*tmp*)
+string0_ifoldleft
+  (cs, r0) =
+(
+gseq_ifoldleft<gseq><cs,c0>(cs, r0)
+) where
+{
+impltmp
+gseq_ifoldleft$fopr<gseq><cs,c0><r0>(r0, i0, c0) =
+  string0_ifoldleft$fopr<r0>(r0, i0, c0)
+} (* end of [string0_ifoldleft] *)
+
+
 (* end of [gseq_string.dats] *)

--- a/libats/SATS/unsafe.sats
+++ b/libats/SATS/unsafe.sats
@@ -135,12 +135,10 @@ stropt1_vt2t
 (* ****** ****** *)
 
 castfn
-{a:tflt}
-list0_vt2t
+list0_vt2t{a:tflt}
 (xs: !list0_vt(a)):<> list0(a)
 castfn
-{a:tflt}
-list1_vt2t
+list1_vt2t{a:tflt}
 {n:int}(xs: !list1_vt(a, n)):<> list1(a, n)
 
 (* ****** ****** *)

--- a/utils/tempacc/DATS/atscc_main.dats
+++ b/utils/tempacc/DATS/atscc_main.dats
@@ -78,13 +78,18 @@ issome(opt) = stropt0_isneqz(,(opt))
 //
 (* ****** ****** *)
 
+(*
 #include "./util.dats"
+*)
+#staload UTIL = "./../SATS/util.sats"
+#staload _ = "./util.dats"
+(* #staload _ = "./util.dats" *)
 
 (* ****** ****** *)
 //
 extern fun filename_test_ext(xs: string, ys: string): bool
 
-implfun filename_test_ext(xs, ys) = to_booln(ext_cmp(xs, ys))
+implfun filename_test_ext(xs, ys) = $UTIL.to_booln($UTIL.ext_cmp(xs, ys))
 
 #macdef
 isfilsats(name) = filename_test_ext(,(name), "sats")//".sats")
@@ -115,7 +120,7 @@ local
 fun
 auxmain(path: string, sfx: string) : string = res where
 {
-  val-(base2, ext) = base_ext(path)
+  val-(base2, ext) = $UTIL.base_ext(path)
   val res = string0_append($UN.castvwtp1{string0}base2, sfx)
   val () = string0_vt_free(base2)
   val () = string0_vt_free(ext)

--- a/utils/tempacc/DATS/atscc_main.dats
+++ b/utils/tempacc/DATS/atscc_main.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -32,30 +32,38 @@
 (* Start time: July, 2013 *)
 
 (* ****** ****** *)
+
+(* Modified by: Richard Kent *)
+(* Start time: June 2019 *)
+
+(* ****** ****** *)
 //
+(*
 #include
 "share/atspre_staload.hats"
+*)
+#include "share/HATS/temptory_staload_bucs320.hats"
 //
 (* ****** ****** *)
 //
-staload
+#staload
 STDLIB =
 "libats/libc/SATS/stdlib.sats"
-staload
+#staload
 UNISTD =
 "libats/libc/SATS/unistd.sats"
 //
 (* ****** ****** *)
 
-staload UN = $UNSAFE
+#staload UN = "libats/SATS/unsafe.sats"
 
 (* ****** ****** *)
 
-staload "./../SATS/atscc.sats"
+#staload "./../SATS/atscc.sats"
 
 (* ****** ****** *)
 
-staload _(*anon*) = "./atscc_util.dats"
+#staload _(*anon*) = "./atscc_util.dats"
 
 (* ****** ****** *)
 
@@ -63,19 +71,27 @@ typedef ca = commarg
 
 (* ****** ****** *)
 //
-macdef
-unsome(opt) = stropt_unsome(,(opt))
-macdef
-issome(opt) = stropt_is_some(,(opt))
+#macdef
+unsome(opt) = $UN.stropt0_unsome(,(opt))
+#macdef
+issome(opt) = stropt0_isneqz(,(opt))
 //
 (* ****** ****** *)
+
+#include "./util.dats"
+
+(* ****** ****** *)
 //
-macdef
-isfilsats(name) = filename_test_ext(,(name), "sats")
-macdef
-isfildats(name) = filename_test_ext(,(name), "dats")
-macdef
-isfilhats(name) = filename_test_ext(,(name), "hats")
+extern fun filename_test_ext(xs: string, ys: string): bool
+
+implfun filename_test_ext(xs, ys) = to_booln(ext_cmp(xs, ys))
+
+#macdef
+isfilsats(name) = filename_test_ext(,(name), "sats")//".sats")
+#macdef
+isfildats(name) = filename_test_ext(,(name), "dats")//".dats")
+#macdef
+isfilhats(name) = filename_test_ext(,(name), "hats")//".hats")
 //
 (* ****** ****** *)
 
@@ -86,93 +102,24 @@ argv_getopt_at
   n: int n, argv: !argv(n), i: int i
 ) : stropt =
 (
-  if i < n then stropt_some (argv[i]) else stropt_none()
+  if i < n then stropt0_some (argv[i]) else stropt0_none()
 ) (* end of [argv_getopt_at] *)
 
 (* ****** ****** *)
 
+
+(* ****** ****** *)
+
 local
-//
-// HX: this is a bit heavy-handed, but ...
-//
-fun auxmain
-(
-  path: string, sfx: string
-) : string = let
-//
-val
-(
-  fpf | base
-) = filename_get_base (path)
-val base2 = g1ofg0 ($UN.strptr2string (base))
-val nb = string1_length (base2)
-//
-val (fpf2 | ext) = filename_get_ext (base2)
-val isext = strptr2ptr(ext) > 0
-//
-#define CHR1 '\001'
-//
-val res =
-(
-if isext then let
-//
-val ne =
-  string0_length ($UN.strptr2string (ext))
-val len = nb+i2sz(2) // HX: 2 -> .c
-//
-implement
-string_tabulate$fopr<>
-  (i) = let
-//
-val i = g1ofg0(i)
-val ne1 = succ (ne)
-//
-in
-//
-case+ 0 of
-| _ when (i+ne1 = nb) => '_'
-| _ when (i < nb) => base2[i]
-| _ when (i = nb+i2sz(0)) => '.'
-| _ when (i = nb+i2sz(1)) => 'c'
-| _ => CHR1
-//
-end // end of [string_tabulate$fwork]
-//
-in
-  strnptr2string(string_tabulate(len))
-end else let
-//
-val sfx = g1ofg0(sfx)
-val len = nb+string1_length(sfx)
-//
-implement
-string_tabulate$fopr<>
-  (i) = let
-//
-val i = g1ofg0(i) in
-//
-case+ 0 of
-| _ when (i < nb) => base2[i]
-| _ when (i < len) => let
-    extern praxi
-    __assert{i,j:int}
-      (size_t i, size_t j): [i >= j] void
-    prval () = __assert (i, nb) in sfx[i-nb]
-  end // end of [_ when ...]
-| _ => CHR1
-//
-end // end of [string_tabulate$fwork]
-//
-in
-  strnptr2string(string_tabulate(len))
-end // end of [if]
-) : string // end of [val]
-//
-prval () = fpf(base) and () = fpf2(ext)
-//
-in
-  res
-end // end of [auxmain]
+
+fun
+auxmain(path: string, sfx: string) : string = res where
+{
+  val-(base2, ext) = base_ext(path)
+  val res = string0_append($UN.castvwtp1{string0}base2, sfx)
+  val () = string0_vt_free(base2)
+  val () = string0_vt_free(ext)
+}
 
 in (* in of [local] *)
 
@@ -182,8 +129,8 @@ atscc_outname
 in
 //
 if flag = 0
-  then auxmain (path, "@sats.c")
-  else auxmain (path, "@dats.c")
+  then auxmain (path, "_sats.c")
+  else auxmain (path, "_dats.c")
 // end of [if]
 //
 end // end of [atscc_outname]
@@ -226,54 +173,54 @@ in
 case+ 0 of
 //
 | _ when (str0="-h") => let
-    val res = list_vt_cons{ca}(CAhelp(), res)
+    val res = list0_vt_cons{ca}(CAhelp(), res)
   in
     aux0 (n, argv, i+1, res)
-  end // end of [_ when ...]  
+  end // end of [_ when ...]
 //
 | _ when (str0="--help") => let
-    val res = list_vt_cons{ca}(CAhelp(), res)
+    val res = list0_vt_cons{ca}(CAhelp(), res)
   in
     aux0 (n, argv, i+1, res)
-  end // end of [_ when ...]  
+  end // end of [_ when ...]
 //
 | _ when (str0="-hats") => let
-    val res = list_vt_cons{ca}(CAhats(), res)
+    val res = list0_vt_cons{ca}(CAhats(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 //
 | _ when (str0="-vats") => let
-    val res = list_vt_cons{ca}(CAvats(), res)
+    val res = list0_vt_cons{ca}(CAvats(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 //
 | _ when (str0="-ccats") => let
-    val res = list_vt_cons{ca}(CAccats(), res)
+    val res = list0_vt_cons{ca}(CAccats(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 | _ when (str0="-tcats") => let
-    val res = list_vt_cons{ca}(CAtcats(), res)
+    val res = list0_vt_cons{ca}(CAtcats(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 //
 | _ when (str0="--gline") => let
-    val res = list_vt_cons{ca}(CAgline(), res)
+    val res = list0_vt_cons{ca}(CAgline(), res)
   in
     aux0 (n, argv, i+1, res)
-  end // end of [_ when ...]  
+  end // end of [_ when ...]
 //
 | _ when (str0="-verbose") => let
-    val res = list_vt_cons{ca}(CAverbose(), res)
+    val res = list0_vt_cons{ca}(CAverbose(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 //
 | _ when (str0="-cleanaft") => let
-    val res = list_vt_cons{ca}(CAcleanaft(), res)
+    val res = list0_vt_cons{ca}(CAcleanaft(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
@@ -307,21 +254,21 @@ case+ 0 of
 | _ when (
     str0="--tlcalopt-disable"
   ) => let
-    val res = list_vt_cons{ca}(CA_tlcalopt_disable(), res)
+    val res = list0_vt_cons{ca}(CA_tlcalopt_disable(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 | _ when (
     str0="--constraint-ignore"
   ) => let
-    val res = list_vt_cons{ca}(CA_constraint_ignore(), res)
+    val res = list0_vt_cons{ca}(CA_constraint_ignore(), res)
   in
     aux0 (n, argv, i+1, res)
   end // end of [_ when ...]
 //
 | _ => let
     val res =
-      list_vt_cons{ca}(CA_CCOMPitm(str0), res)
+      list0_vt_cons{ca}(CA_CCOMPitm(str0), res)
     // end of [val]
   in
     aux0 (n, argv, i+1, res)
@@ -343,7 +290,7 @@ aux1_atsccomp
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAatsccomp(opt), res)
+  val res = list0_vt_cons{ca}(CAatsccomp(opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_atsccomp]
@@ -362,7 +309,7 @@ aux1_iats
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAiats(0, opt), res)
+  val res = list0_vt_cons{ca}(CAiats(0, opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_iats]
@@ -379,7 +326,7 @@ aux1_iiats
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAiats(1, opt), res)
+  val res = list0_vt_cons{ca}(CAiats(1, opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_iiats]
@@ -398,7 +345,7 @@ aux1_dats
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAdats(0, opt), res)
+  val res = list0_vt_cons{ca}(CAdats(0, opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_dats]
@@ -415,7 +362,7 @@ aux1_ddats
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAdats(1, opt), res)
+  val res = list0_vt_cons{ca}(CAdats(1, opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_ddats]
@@ -434,7 +381,7 @@ aux1_fsats
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAfilats(0, opt), res)
+  val res = list0_vt_cons{ca}(CAfilats(0, opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_fsats]
@@ -451,7 +398,7 @@ aux1_fdats
 , res: commarglst_vt
 ) : commarglst_vt = let
   val opt = argv_getopt_at (n, argv, i)
-  val res = list_vt_cons{ca}(CAfilats(1, opt), res)
+  val res = list0_vt_cons{ca}(CAfilats(1, opt), res)
 in
   if i < n then aux0 (n, argv, i+1, res) else res
 end // end of [aux1_fdats]
@@ -465,12 +412,12 @@ atsccproc_commline
 prval (
 ) = lemma_argv_param (argv)
 //
-val res = list_vt_nil{ca}()
+val res = list0_vt_nil{ca}()
 val res = aux0 (argc, argv, 0, res)
-val res = list_vt_reverse (res)
+val res = list0_vt_reverse (res)
 //
 in
-  list_vt2t(res)
+  g0ofg1(list1_vt2t(g1ofg0(res)))
 end // end of [atsccproc_commline]
 
 end (* end of [local] *)
@@ -493,14 +440,14 @@ case+ ca of
   {
     val (
     ) = res :=
-      list_vt_cons{string}("--typecheck", res)
+      list0_vt_cons{string}("--typecheck", res)
     // end of [val]
   }
 //
 | CAgline() =>
   {
     val (
-    ) = res := list_vt_cons{string}("--gline", res)
+    ) = res := list0_vt_cons{string}("--gline", res)
   }
 //
 | CAdats(_, opt) =>
@@ -517,7 +464,7 @@ case+ ca of
   {
     val (
     ) = res :=
-      list_vt_cons{string}("--tlcalopt-disable", res)
+      list0_vt_cons{string}("--tlcalopt-disable", res)
     // end of [val]
   }
 //
@@ -525,7 +472,7 @@ case+ ca of
   {
     val (
     ) = res :=
-      list_vt_cons{string}("--constraint-ignore", res)
+      list0_vt_cons{string}("--constraint-ignore", res)
     // end of [val]
   }
 //
@@ -538,16 +485,16 @@ and aux_dats
   path: string, res: &res >> _
 ) : void =
 {
-val () = res := list_vt_cons{string}("-DATS", res)
-val () = res := list_vt_cons{string}(  path , res)
+val () = res := list0_vt_cons{string}("-DATS", res)
+val () = res := list0_vt_cons{string}(  path , res)
 }
 and aux_iats
 (
   path: string, res: &res >> _
 ) : void =
 {
-val () = res := list_vt_cons{string}("-IATS", res)
-val () = res := list_vt_cons{string}(  path , res)
+val () = res := list0_vt_cons{string}("-IATS", res)
+val () = res := list0_vt_cons{string}(  path , res)
 }
 //
 fun auxlst
@@ -557,13 +504,13 @@ fun auxlst
 in
 //
 case+ cas of
-| list_nil
+| list0_nil
     () => ((*void*))
-  // list_nil
-| list_cons
+  // list0_nil
+| list0_cons
     (ca, cas) => let
     val () = aux(ca, i, res) in auxlst(cas, i+1, res)
-  end // end of [list_cons]
+  end // end of [list0_cons]
 //
 end // end of [auxlst]
 
@@ -571,10 +518,10 @@ fun auxout
   (cas: commarglst): bool =
 (
 case+ cas of
-| list_nil
+| list0_nil
     () => true
-  // list_nil
-| list_cons
+  // list0_nil
+| list0_cons
     (ca, cas) =>
   (
     case+ ca of CAtcats() => false | _ => auxout(cas)
@@ -587,7 +534,7 @@ implement
 atsoptline_make
   (cas, ca0) = let
 //
-var res: res = list_vt_nil()
+var res: res = list0_vt_nil()
 val () = auxlst(cas, 1(*i*), res)
 //
 val () =
@@ -597,13 +544,13 @@ case+ ca0 of
   {
     val () =
     res :=
-    list_vt_cons{string}("--help", res)
+    list0_vt_cons{string}("--help", res)
   }
 | CAvats() =>
   {
     val () =
     res :=
-    list_vt_cons{string}("--version", res)
+    list0_vt_cons{string}("--version", res)
   }
 | CAfilats(knd, opt) =>
   if issome (opt) then
@@ -615,25 +562,25 @@ case+ ca0 of
     if auxout (cas) then
     {
       val () =
-        res := list_vt_cons{string}("--output", res)
+        res := list0_vt_cons{string}("--output", res)
       // end of [val]
-      val () = res := list_vt_cons{string}(outname, res)
+      val () = res := list0_vt_cons{string}(outname, res)
     } // end of [if] // end of [val]
 //
     val () =
-      if knd = 0 then res := list_vt_cons{string}("--static", res)
+      if knd = 0 then res := list0_vt_cons{string}("--static", res)
     // end of [val]
     val () =
-      if knd > 0 then res := list_vt_cons{string}("--dynamic", res)
+      if knd > 0 then res := list0_vt_cons{string}("--dynamic", res)
     // end of [val]
-    val () = res := list_vt_cons{string}(name, res)
+    val () = res := list0_vt_cons{string}(name, res)
 //
   } (* end of [if] *)
 | _ (*rest-of-commarg*) => ((*void*))
 ) : void // end of [val]
 //
 in
-  list_vt_reverse(res)
+  list0_vt_reverse(res)
 end // end of [atsoptline_make]
 
 end // end of [local]
@@ -643,9 +590,9 @@ end // end of [local]
 local
 //
 vtypedef res = stringlst_vt
-vtypedef ress = List0_vt (stringlst_vt)
+vtypedef ress = list0_vt (stringlst_vt)
 //
-macdef snoc = list_vt_snoc
+#macdef snoc = list0_vt_extend
 //
 fun auxlst
 (
@@ -655,27 +602,27 @@ in
 //
 case+ cas2 of
 //
-| list_nil() => let
-    val () = list_vt_free (cas1) in (*nothing*)
-  end (* end of [list_nil] *)
+| list0_nil() => let
+    val () = list0_vt_free (cas1) in (*nothing*)
+  end (* end of [list0_nil] *)
 //
-| list_cons
+| list0_cons
     (ca2, cas2) =>
   (
     case+ ca2 of
 //
     | CAhats() => let
         val res =
-          atsoptline_make ($UN.list_vt2t(cas1), ca2)
-        val () = ress := list_vt_cons{res}(res, ress)
+          atsoptline_make ($UN.list0_vt2t(cas1) , ca2)
+        val () = ress := list0_vt_cons{res}(res, ress)
       in
         auxlst (cas1, cas2, ress)
       end (* end of [CAhats] *)
 //
     | CAvats() => let
         val res =
-          atsoptline_make ($UN.list_vt2t(cas1), ca2)
-        val () = ress := list_vt_cons{res}(res, ress)
+          atsoptline_make ($UN.list0_vt2t(cas1), ca2)
+        val () = ress := list0_vt_cons{res}(res, ress)
       in
         auxlst (cas1, cas2, ress)
       end (* end of [CAvats] *)
@@ -701,8 +648,8 @@ case+ cas2 of
 //
     | CAfilats _ => let
         val res =
-          atsoptline_make ($UN.list_vt2t(cas1), ca2) 
-        val () = ress := list_vt_cons{res}(res, ress)
+          atsoptline_make ($UN.list0_vt2t(cas1), ca2)
+        val () = ress := list0_vt_cons{res}(res, ress)
       in
         auxlst (cas1, cas2, ress)
       end (* end of [CAfilats] *)
@@ -716,7 +663,7 @@ case+ cas2 of
 //
     | _(*ignored*) => auxlst (cas1, cas2, ress)
 //
-  ) (* end of [list_cons] *)
+  ) (* end of [list0_cons] *)
 //
 end // end of [auxlst]
 
@@ -726,11 +673,11 @@ implement
 atsoptline_make_all
   (cas0) = let
 //
-var ress: ress = list_vt_nil
-val () = auxlst (list_vt_nil, cas0, ress)
+var ress: ress = list0_vt_nil
+val () = auxlst (list0_vt_nil, cas0, ress)
 //
 in
-  list_vt_reverse (ress)
+  list0_vt_reverse (ress)
 end // end of [atsoptline_make_all]
 
 end // end of [local]
@@ -768,16 +715,16 @@ case+ ca of
 | CAdats(_, opt) =>
   if issome(opt) then
   {
-    val () = res := list_vt_cons{string}("-D", res)
-    val () = res := list_vt_cons{string}(unsome(opt), res)
+    val () = res := list0_vt_cons{string}("-D", res)
+    val () = res := list0_vt_cons{string}(unsome(opt), res)
   } else ((*void*)) // end of [if]
 //
 | CAiats(0, opt) => ()
 | CAiats(_, opt) =>
   if issome (opt) then
   {
-    val () = res := list_vt_cons{string}("-I", res)
-    val () = res := list_vt_cons{string}(unsome(opt), res)
+    val () = res := list0_vt_cons{string}("-I", res)
+    val () = res := list0_vt_cons{string}(unsome(opt), res)
   } else ((*void*)) // end of [if]
 //
 | CAfilats(0, opt) =>
@@ -800,18 +747,18 @@ and aux_fsats
   (path: string, res: &res >> _): void =
 {
   val outname = atscc_outname (0(*sta*), path)
-  val () = res := list_vt_cons{string}(outname, res)
+  val () = res := list0_vt_cons{string}(outname, res)
 }
 and aux_fdats
   (path: string, res: &res >> _): void =
 {
-  val outname = atscc_outname (0(*sta*), path)
-  val () = res := list_vt_cons{string}(outname, res)
+  val outname = atscc_outname (1(*dyn*), path)
+  val () = res := list0_vt_cons{string}(outname, res)
 }
 and aux_CCOMPitm
   (item: string, res: &res >> _): void =
 {
-  val () = res := list_vt_cons{string}(item, res)
+  val () = res := list0_vt_cons{string}(item, res)
 }
 
 fun auxlst
@@ -826,12 +773,12 @@ val () = println! ("auxlst")
 in
 //
 case+ cas of
-| list_nil
+| list0_nil
     () => ((*void*))
-| list_cons
+| list0_cons
     (ca, cas) => let
     val () = aux (ca, i, res) in auxlst (cas, i+1, res)
-  end // end of [list_cons]
+  end // end of [list0_cons]
 //
 end // end of [loop]
 
@@ -841,12 +788,12 @@ implement
 atsccompline_make
   (cas0) = let
 //
-var res: res = list_vt_nil
-val-list_cons(ca, cas) = cas0
+var res: res = list0_vt_nil
+val-list0_cons(ca, cas) = cas0
 val () = auxlst(cas, 1(*i*), res)
 //
 in
-  list_vt_reverse(res)
+  list0_vt_reverse(res)
 end // end of [atsccompline_make]
 
 end // end of [local]
@@ -858,24 +805,24 @@ local
 #define CNUL '\0'
 #define SPACE " "
 
-overload + with add_ptr0_bsz of 10
+#symload + with g0add_ptr_int of 10//add_ptr0_bsz of 10
 
 (* ****** ****** *)
 
 fun
 auxstr
 (
-  p0: &ptr >> _, n0: &size_t >> _, x: string
+  p0: &ptr >> _, n0: &size >> _, x: string
 ) : int = let
 //
-val n = string_length (x)
+val n = string0_length (x)
 //
 in
 //
 if n0 > n then let
   val _ = $extfcall
   (
-    ptr, "memcpy", p0, string2ptr(x), n
+    ptr, "memcpy", p0, ptrof(x), n
   ) // end of [val]
   val () = p0 := p0 + n and () = n0 := n0 - n
 in
@@ -887,12 +834,12 @@ end // end of [auxstr]
 fun
 auxstrlst_sep
 (
-  p0: &ptr >> _, n0: &size_t >> _, sep: string, xs: stringlst
+  p0: &ptr >> _, n0: &size >> _, sep: string, xs: list0(string)//stringlst
 ) : int = let
 in
 //
 case+ xs of
-| list_cons
+| list0_cons
     (x, xs) => let
     val err = auxstr (p0, n0, sep)
     val err =
@@ -901,8 +848,8 @@ case+ xs of
     ) : int // end of [val]
   in
     if err = 0 then auxstrlst_sep (p0, n0, sep, xs) else ~1
-  end // end of [list_cons]
-| list_nil() => 0(*success*)
+  end // end of [list0_cons]
+| list0_nil() => 0(*success*)
 //
 end // end of [auxstrlst_sep]
 
@@ -912,18 +859,15 @@ fun
 auxline
 (
   cmd: string
-, args: stringlst
-, bsz: sizeGte(1)
-) : Strptr1 = let
+, args: list0(string)//stringlst
+, bsz: Sizegte(1)
+) : cptr(char) = let//Strptr1 = let
 //
-val (
-  pfat
-, pfgc
-| p_st
-) = malloc_gc (bsz)
+//val (pfat, pfgc| p_st) = malloc_gc (bsz)
+val p_st = $UN.calloc<char>(bsz)
 //
-var p0: ptr = p_st
-var n0: size_t = bsz
+var p0: ptr = cptr2ptr(p_st): ptr
+var n0: size = bsz
 val sep: string = SPACE
 //
 val err = auxstr (p0, n0, cmd)
@@ -936,10 +880,13 @@ in
 //
 if err = 0
   then let
-  val () = $UN.ptr0_set<char> (p0, CNUL) in
-  $UN.castvwtp0{Strptr1}((pfat, pfgc | p_st))
-  end else let
-  val () = mfree_gc (pfat, pfgc | p_st) in auxline (cmd, args, bsz+bsz)
+  val () = $UN.ptr0_set<char> (p0, CNUL) in (p_st) end
+    //$UN.castvwtp0{Strptr1}((pfat, pfgc | p_st))
+  else let
+    (* val () = mfree_gc (pfat, pfgc | p_st)  *)
+    val () = $UN.cfree(p_st)
+  in
+    auxline (cmd, args, bsz+bsz)
   end // end of [else]
 // end of [if]
 end // end of [auxline]
@@ -954,25 +901,28 @@ atsoptline_exec
 //
 val bsz = 1024 // HX: more or less arbitrary
 //
-val [l:addr]
-  line = auxline (atsopt, $UN.list_vt2t(arglst), i2sz(bsz))
-val () = list_vt_free (arglst)
+//val [l:addr] line = auxline (atsopt, $UN.list0_vt2t(arglst), i2sz(bsz))
+val line = auxline (atsopt, $UN.list0_vt2t(arglst), i2sz(bsz))
+val () = list0_vt_free (arglst)
+//
+
+val () =
+if flag > 0 then
+{
+  val () = println! ("exec(", $UN.castvwtp1{string}line, ")")
+} (* end of [if] *)
+//
+val status = //$STDLIB.system ($UN.strptr2string(line))
+  $extfcall(int, "system", $UN.castvwtp1{string}line)
 //
 val () =
 if flag > 0 then
 {
-  val () = fprintln! (stderr_ref, "exec(", line, ")")
+  val () = println! ("exec(", $UN.castvwtp1{string}line, ") = ", status)
 } (* end of [if] *)
 //
-val status = $STDLIB.system ($UN.strptr2string(line))
-//
-val () =
-if flag > 0 then
-{
-  val () = fprintln! (stderr_ref, "exec(", line, ") = ", status)
-} (* end of [if] *)
-//
-val () = strptr_free (line)
+(* val () = strptr_free (line) *)
+val () = $UN.cfree(line)
 //
 in
   status
@@ -985,7 +935,7 @@ atsoptline_exec_all
   (flag, atsopt, lines) = let
 //
 vtypedef
-lines = List_vt(stringlst_vt)
+lines = list0_vt(stringlst_vt)
 //
 fun auxlst
 (
@@ -994,17 +944,17 @@ fun auxlst
 in
 //
 case+ lines of
-| ~list_vt_nil
+| ~list0_vt_nil
     () => status
-  // list_vt_nil
-| ~list_vt_cons
+  // list0_vt_nil
+| ~list0_vt_cons
     (line, lines) => let
     val status = (
       if status = 0
         then
           atsoptline_exec (flag, atsopt, line)
         else let
-          val () = list_vt_free (line) in status
+          val () = list0_vt_free (line) in status
         end // end of [else]
       // end of [if]
     ) : int // end of [val]
@@ -1015,6 +965,7 @@ case+ lines of
 end // end of [auxlst]
 //
 in
+
   auxlst (lines, 0(*success*))
 end // end of [atsoptline_exec_all]
 
@@ -1031,7 +982,7 @@ auxlst
 ) : bool =
 //
 case+ cas of
-| list_cons
+| list0_cons
     (ca, cas) => let
   in
     case+ ca of
@@ -1043,14 +994,14 @@ case+ cas of
     | CAverbose() => auxlst (cas, n)
     | _ (*rest*) => auxlst (cas, n+1)
   end (* end of [cons] *)
-| list_nil ((*void*)) =>
+| list0_nil ((*void*)) =>
     if n > 0 then true else false
 //
 in
 //
 case+ cas of
-| list_nil () => false
-| list_cons (_, cas) => auxlst (cas, 0)
+| list0_nil () => false
+| list0_cons (_, cas) => auxlst (cas, 0)
 //
 end // end of [atsccomp_cont]
 
@@ -1062,25 +1013,26 @@ atsccompline_exec
 //
 val bsz = 1024 // HX: more or less arbitrary
 //
-val [l:addr]
-  line = auxline (atsccomp, $UN.list_vt2t(arglst), i2sz(bsz))
-val () = list_vt_free (arglst)
+val //[l:addr]
+  line = auxline (atsccomp, $UN.list0_vt2t(arglst), i2sz(bsz))
+val () = list0_vt_free (arglst)
 //
 val (
 ) = if flag > 0 then
 {
-  val () = fprintln! (stderr_ref, "exec(", line, ")")
+  val () = println! ("exec(", $UN.castvwtp1{string}line, ")")
 } (* end of [if] *)
 //
-val status = $STDLIB.system ($UN.strptr2string(line))
+val status = //$STDLIB.system ($UN.strptr2string(line))
+  $extfcall(int, "system", line)
 //
 val (
 ) = if flag > 0 then
 {
-  val () = fprintln! (stderr_ref, "exec(", line, ") = ", status)
+  val () = println! ("exec(", $UN.castvwtp1{string}line, ") = ", status)
 } (* end of [if] *)
 //
-val () = strptr_free (line)
+val () = $UN.cfree(line)//strptr_free (line)
 //
 in
   status
@@ -1096,13 +1048,13 @@ atscc_is_help
 in
 //
 case+ cas of
-| list_cons
+| list0_cons
     (ca, cas) =>
   (
     case+ ca of
     | CAhelp() => true | _ => atscc_is_help(cas)
   )
-| list_nil((*void*)) => false
+| list0_nil((*void*)) => false
 //
 end // end of [atscc_is_help]
 
@@ -1114,13 +1066,13 @@ atscc_is_verbose
 in
 //
 case+ cas of
-| list_cons
+| list0_cons
     (ca, cas) =>
   (
     case+ ca of
     | CAverbose() => true | _ => atscc_is_verbose(cas)
   )
-| list_nil((*void*)) => false
+| list0_nil((*void*)) => false
 //
 end // end of [atscc_verbose]
 
@@ -1132,13 +1084,13 @@ atscc_cleanaft_cont
 in
 //
 case+ cas of
-| list_cons
+| list0_cons
     (ca, cas) =>
   (
     case+ ca of
     | CAcleanaft () => true | _ => atscc_cleanaft_cont(cas)
   )
-| list_nil((*void*)) => false
+| list0_nil((*void*)) => false
 //
 end // end of [atscc_cleanaft_cont]
 
@@ -1155,7 +1107,8 @@ fun rmf
 if issome(opt) then
 {
   val _(*err*) =
-    $UNISTD.unlink(atscc_outname(flag, unsome(opt)))
+    //$UNISTD.unlink(atscc_outname(flag, unsome(opt)))
+      $extfcall(int, "unlink", atscc_outname(flag, unsome(opt)))
   // end of [val]
 } // end of [if]
 ) (* end of [rmf] *)
@@ -1167,7 +1120,7 @@ fun auxlst
 in
 //
 case+ cas of
-| list_cons
+| list0_cons
     (ca, cas) =>
   (
     case+ ca of
@@ -1178,7 +1131,7 @@ case+ cas of
       ) (* end of [CAfilats] *)
     | _(*skipped*) => auxlst (cas)
   )
-| list_nil((*void*)) => ()
+| list0_nil((*void*)) => ()
 //
 end // end of [auxlst]
 //
@@ -1189,9 +1142,15 @@ val () =
 if flag > 0 then
 {
 //
+(*
 val () = fprintln!
 (
-  stderr_ref, "atscc: removal of generated C-files is done."
+  the_stderr<>(), "atscc: removal of generated C-files is done."
+)
+*)
+val () = println!
+(
+  "atscc: removal of generated C-files is done."
 )
 //
 } (* end of [val] *)

--- a/utils/tempacc/DATS/atscc_print.dats
+++ b/utils/tempacc/DATS/atscc_print.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -33,21 +33,21 @@
 
 (* ****** ****** *)
 //
-#include
-"share/atspre_staload.hats"
+(* #include "share/atspre_staload.hats" *)
+#include "share/HATS/temptory_staload_bucs320.hats"
 //
 (* ****** ****** *)
 //
-staload
+#staload
 STDLIB =
 "libats/libc/SATS/stdlib.sats"
-staload
+#staload
 _(*anon*) =
-"libats/libc/DATS/stdlib.dats"
+"libats/DATS/stdlib.dats"
 //
 (* ****** ****** *)
 //
-#staload UN = $UNSAFE
+// #staload UN = "libats/SATS/unsafe.sats"//$UNSAFE
 //
 (* ****** ****** *)
 //
@@ -59,10 +59,19 @@ _(*anon*) =
 
 (* ****** ****** *)
 
-macdef
+(*
+#macdef
 unsome(opt) = stropt_unsome(,(opt))
-macdef
+#macdef
 issome(opt) = stropt_is_some(,(opt))
+*)
+#macdef
+unsome(opt) = $UN.stropt0_unsome(,(opt))
+#macdef
+issome(opt) = stropt0_isneqz(,(opt))
+
+#macdef snoc = list0_vt_extend
+#macdef list0_vt_snoc = list0_vt_extend
 
 (* ****** ****** *)
 
@@ -71,18 +80,17 @@ typedef ca = commarg
 (* ****** ****** *)
 
 implement
-fprint_commarg
-  (out, ca) = let
+print_commarg(ca) = let
 //
-macdef
-prstr(x) = fprint_string(out, ,(x))
+#macdef
+prstr(x) = print_string(,(x))
 //
-macdef
+#macdef
 propt (opt) = let
 //
 val opt = ,(opt) in
 //
-  if issome(opt) then fprint_string(out, unsome(opt))
+  if issome(opt) then print_string(unsome(opt))
 end // end of [propt]
 //
 in
@@ -152,20 +160,17 @@ end // end of [fprint_commarg]
 (* ****** ****** *)
 
 implement
-fprint_commarglst
-  (out, cas) = let
+print_commarglst
+  (cas) = let
 //
-implement
-fprint_val<ca>
-  (out, x) =
-  fprint_commarg(out, x)
+impltmp
+print$val<ca>(x) = print_commarg(x)
 //
-implement
-fprint_list$sep<>
-  (out) = fprint_string(out, " ")
+impltmp
+list0_print$sep<>() = print_string(" ")
 //
 in
-  fprint_list<ca> (out, cas)
+  list0_print<ca> (cas)
 end // end of [fprint_ccomarglst]
 
 (* ****** ****** *)
@@ -184,7 +189,8 @@ case+ ca of
 //
 | CAtcats () =>
   {
-    val () = fprint (out, " --typecheck")
+    //val () = fprint (out, " --typecheck")
+    val () = print (" --typecheck")
   }
 //
 | CAdats (_, opt) =>
@@ -207,7 +213,8 @@ aux_dats
   out: FILEref, def0: string
 ) : void =
 {
-  val () = fprint! (out, " -DATS ", def0)
+  //val () = fprint! (out, " -DATS ", def0)
+  val () = print! (" -DATS ", def0)
 }
 and
 aux_iats
@@ -215,7 +222,8 @@ aux_iats
   out: FILEref, path: string
 ) : void =
 {
-  val () = fprint! (out, " -IATS ", path)
+  //val () = fprint! (out, " -IATS ", path)
+  val () = print! (" -IATS ", path)
 }
 //
 fun auxlst
@@ -226,12 +234,12 @@ in
 //
 case+ cas of
 //
-| list_cons
+| list0_cons
     (ca, cas) => let
     val () = aux (out, ca, i) in auxlst (out, cas, i+1)
   end // end of [list_cons]
 //
-| list_nil ((*void*)) => ()
+| list0_nil ((*void*)) => ()
 //
 end // end of [auxlst]
 //
@@ -239,7 +247,7 @@ val
 atsopt = atsopt_get ()
 //
 val () =
-  fprint_string (out, atsopt)
+  print_string (atsopt)
 //
 val () = auxlst (out, cas, 1(*i*))
 //
@@ -248,19 +256,23 @@ in
 case+ ca0 of
 | CAvats () =>
   {
-    val () = fprintln! (out, " --version")
+    //val () = fprintln! (out, " --version")
+    val () = println! (" --version")
   }
 | CAfilats (knd, opt) =>
   if issome (opt) then
   {
     val name = unsome(opt)
     val outname = atscc_outname (knd, name)
-    val () = fprint! (out, " --output ", outname)
+    //val () = fprint! (out, " --output ", outname)
+    val () = print! (" --output ", outname)
     val () =
-      if knd = 0 then fprintln! (out, " --static ", name)
+    //  if knd = 0 then fprintln! (out, " --static ", name)
+      if knd = 0 then println! (" --static ", name)
     // end of [val]
     val () =
-      if knd > 0 then fprintln! (out, " --dynamic ", name)
+      //if knd > 0 then fprintln! (out, " --dynamic ", name)
+      if knd > 0 then println! (" --dynamic ", name)
     // end of [val]
   } (* end of [if] *)
 | _ (* rest-of-CA *) => ((*void*))
@@ -280,40 +292,38 @@ fun auxlst
 in
 //
 case+ cas2 of
-| list_nil
-    ((*void*)) => let
-    val () = list_vt_free (cas1) in (*nothing*)
+| list0_nil((*void*)) => let
+    val () = list0_vt_free (cas1) in (*nothing*)
   end (* end of [list_nil] *)
 //
-| list_cons
-    (ca2, cas2) =>
+| list0_cons(ca2, cas2) =>
   (
     case+ ca2 of
 //
     | CAvats () => let
         val () =
-          fprint_atsoptline (out, $UN.list_vt2t(cas1), ca2)
+          fprint_atsoptline (out, $UN.list0_vt2t(cas1), ca2)
         // end of [val]
       in
         auxlst (out, cas1, cas2)
       end (* end of [CAvats] *)
     | CAtcats () => let
         val cas1 =
-          list_vt_snoc (cas1, ca2) in auxlst (out, cas1, cas2)
+          list0_vt_snoc (cas1, ca2) in auxlst (out, cas1, cas2)
       end (* end of [CAtcats] *)
 //
     | CAdats _ => let
         val cas1 =
-          list_vt_snoc (cas1, ca2) in auxlst (out, cas1, cas2)
+          list0_vt_snoc (cas1, ca2) in auxlst (out, cas1, cas2)
       end (* end of [CAdats] *)
     | CAiats _ => let
         val cas1 =
-          list_vt_snoc (cas1, ca2) in auxlst (out, cas1, cas2)
+          list0_vt_snoc (cas1, ca2) in auxlst (out, cas1, cas2)
       end (* end of [CAiats] *)
 //
     | CAfilats _ => let
         val () =
-          fprint_atsoptline (out, $UN.list_vt2t(cas1), ca2)
+          fprint_atsoptline (out, $UN.list0_vt2t(cas1), ca2)
         // end of [val]
       in
         auxlst (out, cas1, cas2)
@@ -326,7 +336,7 @@ case+ cas2 of
 end // end of [auxlst]
 //
 in
-  auxlst (out, list_vt_nil, cas0)
+  auxlst (out, list0_vt_nil, cas0)
 end // end of [fprint_atsoptline_all]
 
 (* ****** ****** *)
@@ -363,7 +373,8 @@ case+ ca of
 | CAdats (_, opt) => (
     if issome (opt) then
     {
-      val () = fprint! (out, " -D ", unsome(opt))
+      (* val () = fprint! (out, " -D ", unsome(opt)) *)
+      val () = print! (" -D ", unsome(opt))
     } else ((*void*)) // end of [if]
   )
 //
@@ -371,7 +382,8 @@ case+ ca of
 | CAiats (_, opt) => (
     if issome (opt) then
     {
-      val () = fprint! (out, " -I ", unsome(opt))
+      //val () = fprint! (out, " -I ", unsome(opt))
+      val () = print! (" -I ", unsome(opt))
     } else ((*void*)) // end of [if]
   )
 //
@@ -397,8 +409,9 @@ aux_fsats
 {
   val outname =
     atscc_outname (0(*sta*), path)
-  val () = fprint (out, ' ')
-  val () = fprint_string (out, outname)
+  (* val () = fprint (out, ' ') *)
+  val () = print (' ')
+  val () = print_string (outname)
 }
 and
 aux_fdats
@@ -406,15 +419,17 @@ aux_fdats
 {
   val outname =
     atscc_outname (1(*dyn*), path)
-  val () = fprint (out, ' ')
-  val () = fprint_string (out, outname)
+  //val () = fprint (out, ' ')
+  val () = print (' ')
+  val () = print_string (outname)
 }
 and
 aux_CCOMPitm
   (out: FILEref, item: string): void =
 {
-  val () = fprint (out, ' ')
-  val () = fprint_string (out, item)
+  //val () = fprint (out, ' ')
+  val () = print (' ')
+  val () = print_string (item)
 }
 
 fun auxlst
@@ -424,18 +439,19 @@ fun auxlst
 in
 //
 case+ cas of
-| list_cons
+| list0_cons
     (ca, cas) => let
     val () = aux (out, ca, i) in auxlst (out, cas, i+1)
   end // end of [list_cons]
-| list_nil ((*void*)) => ()
+| list0_nil ((*void*)) => ()
 //
 end // end of [auxlst]
 //
-val-list_cons (ca, cas) = cas0
+val-list0_cons (ca, cas) = cas0
 //
 val () =
-fprint (out, atsccomp_get ())
+//fprint (out, atsccomp_get ())
+print (atsccomp_get ())
 //
 val () = auxlst (out, cas, 1(*i*))
 val () = fprint_newline (out)

--- a/utils/tempacc/DATS/atscc_util.dats
+++ b/utils/tempacc/DATS/atscc_util.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -33,35 +33,44 @@
 
 (* ****** ****** *)
 //
+#include "share/HATS/temptory_staload_bucs320.hats"
+
+
 #define
 ATSOPT_DEFAULT "tempopt"
 //
 (* ****** ****** *)
 //
 #staload
-STDLIB =
-"libats/libc/SATS/stdlib.sats"
+STDLIB = "libats/libc/SATS/stdlib.sats"
 //
 (* ****** ****** *)
 //
 #staload "./../SATS/atscc.sats"
 //
-macdef
-unsome(opt) = stropt_unsome(,(opt))
-macdef
-issome(opt) = stropt_is_some(,(opt))
+#macdef
+unsome(opt) = stropt0_iseqz<>(,(opt))
+#macdef
+issome(opt) = stropt0_isneqz<>(,(opt))
 //
 (* ****** ****** *)
 
-implement
+impltmp
 {}(*tmp*)
 atsopt_get() = let
 //
-val def =
-  $STDLIB.getenv_gc ("TEMPOPT")
+(* val def = $STDLIB.getenv_gc<>("TEMPOPT") *)
+val def = $extfcall(cptr(char), "getenv", "TEMPOPT")
 //
 in
 //
+if
+def > $UN.cast{cptr(char)}(0)
+then $UN.castvwtp1{string}(def)
+else (* let prval() = strptr_free_null(def) in *)
+ATSOPT_DEFAULT
+//
+(*
 if
 strptr2ptr(def) > 0
 then strptr2string(def)
@@ -70,10 +79,11 @@ else let
 prval() =
  strptr_free_null(def) in ATSOPT_DEFAULT
 //
+*)
 end (* end of [if] *)
 // end of [if]
 //
-end // end of [atsopt_get]
+(* end // end of [atsopt_get] *)
 
 (* ****** ****** *)
 
@@ -174,10 +184,9 @@ performed externally)
 //
 " (* end of [ATSOPT_USAGE] *)
 //
-implement
+impltmp
 {}(*tmp*)
-atsopt_print_usage() =
-fprint_string (stdout_ref, ATSOPT_USAGE)
+atsopt_print_usage() = print_string(ATSOPT_USAGE)
 //
 (* ****** ****** *)
 //
@@ -213,10 +222,22 @@ gcc -std=c99 \
 
 (* ****** ****** *)
 
-implement
+impltmp
 {}(*tmp*)
 atsccomp_get() = let
 //
+val def = $extfcall(cptr(char), "getenv", "TEMPACCOMP")
+//
+in
+//
+if
+def > $UN.cast{cptr(char)}0
+then $UN.castvwtp1{string}(def)
+else (* let prval() = strptr_free_null(def) in *)
+ATSCCOMP_DEFAULT
+//
+end (* end of [if] *)
+(*
 val def =
   $STDLIB.getenv_gc("TEMPACCOMP")
 //
@@ -230,10 +251,11 @@ else let
 end // end of [else]
 //
 end // end of [atsccomp_get]
-  
+*)
+
 (* ****** ****** *)
 
-implement
+impltmp
 {}(*tmp*)
 atsccomp_get2
   (cas) = let
@@ -245,21 +267,21 @@ in
 //
 case+ cas of
 //
-| list_cons
-    (ca, cas) =>
+| list0_cons
+  (ca, cas) =>
   (
   case+ ca of
   | CAatsccomp
       (opt) => (
       if issome(opt)
-        then unsome(opt)
+        then $UN.stropt0_unsome(opt)
         else atsccomp_get2(cas)
       // end of [if]
     ) (* end of [CAatsccomp] *)
   | _ (*void*) => atsccomp_get2(cas)
   ) (* end of [list_cons] *)
 //
-| list_nil() => atsccomp_get()
+| list0_nil() => atsccomp_get()
 //
 end // end of [atsccomp_get2]
 

--- a/utils/tempacc/DATS/tempacc.dats
+++ b/utils/tempacc/DATS/tempacc.dats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -33,13 +33,18 @@
 
 (* ****** ****** *)
 //
+#include "share/HATS/temptory_staload_bucs320.hats"
+(*
 #include
 "share/atspre_staload.hats"
+*)
 //
 (* ****** ****** *)
 //
+(*
 #staload
 "libats/libc/DATS/stdlib.dats"
+*)
 //
 (* ****** ****** *)
 
@@ -64,6 +69,9 @@ var status: int = 0
 //
 val cas =
 atsccproc_commline(argc, argv)
+(*
+val _ = $showtype(cas)
+*)
 //
 // HX-2015-03-22:
 // [tempacc] for [tempacc -vats]
@@ -71,7 +79,7 @@ atsccproc_commline(argc, argv)
 val cas =
 (
 if argc >= 2
-  then cas else cas+'[CAvats]
+  then cas else list0_append<commarg>(cas, g0ofg1('[CAvats]))
 // end of [i]
 ) : commarglst
 //

--- a/utils/tempacc/DATS/util.dats
+++ b/utils/tempacc/DATS/util.dats
@@ -1,24 +1,14 @@
-(*
-#include "share/HATS/temptory_staload_bucs320.hats"
-*)
+#include
+"share/HATS\
+/temptory_staload_bucs320.hats"
 
+#staload "./../SATS/util.sats"
 
-extern
-fun
-to_bool : int -> bool
-implfun
+impltmp{}
 to_bool i = (if i = 0 then false else true)
 
-extern
-fun
-to_booln : int -> bool
-implfun
+impltmp{}
 to_booln i = ~(to_bool i)
-
-
-extern
-fun{}
-str_strr(cs: string, pred: char): int
 
 impltmp{}
 str_strr(cs, ch) = (loop0(cptrof(cs), 0, ~1)) where
@@ -35,19 +25,12 @@ str_strr(cs, ch) = (loop0(cptrof(cs), 0, ~1)) where
   end
 }
 
-extern
-fun{}
-str_cmp(cs: string, match: string): int
-
 impltmp{}
 str_cmp(cs, match) = loop0(cptrof(cs), cptrof(match)) where
 {
   fun loop0(p1: cptr(char), p2: cptr(char)): int = let
     val c1 = $UN.cptr0_get(p1)
     val c2 = $UN.cptr0_get(p2)
-    (*
-    val () = println!("c1,c2 = ", c1, ",", c2)
-    *)
   in
     ifcase iseqz(c1) => (c1 - c2)
     |_=>
@@ -57,15 +40,11 @@ str_cmp(cs, match) = loop0(cptrof(cs), cptrof(match)) where
   end
 }
 
-extern
-fun{}
-ext_cmp(cs: string, match: string): int
-
 impltmp{}
 ext_cmp(cs, match) = let
   val ext0 = str_strr(cs, '.')
 in
-  ifcase ext0 < 0 (* -1 *)=> ~1
+  ifcase ext0 < 0 (* -1 *) => ~1
   | _ => str_cmp(str0, match)
     where
       val i = $UN.cast{usize}(ext0)
@@ -76,70 +55,12 @@ end
 
 (* ****** ****** *)
 
-extern fun{} dirsep_get ():<> [n:int | n > 0] char(n)
-extern fun{} dirsep_gets ():<> string
-extern fun{} dirname_self ():<> string
-extern fun{} dirname_parent ():<> string
-
-(* ****** ****** *)
-
-extern fun{}
-filename_get_ext(name: string):<> string
-
-extern fun{}
-filename_test_ext(name: string, ext: string):<> bool
-
-(* ****** ****** *)
-
-extern fun{}
-filename_get_base (name: string):<> string
-//vStrptr1
-extern fun{}
-filename_test_base (name: string, base: string):<> bool
-
 impltmp{} dirsep_get () = '/'
 impltmp{} dirsep_gets () = "/"
 impltmp{} dirname_self () = "."
 impltmp{} dirname_parent () = ".."
 
-
-extern fun{} string0_rforall(cs: string): bool
-extern fun{} string0_rforall$test(c0: char): bool
-
-impltmp {} string0_rforall(cs) = (loop1(p1))
-where
-{
-
-  val p0 = string0_cptrof(cs)
-
-  val p1 = loop0(p0) where
-  {
-    fun loop0(p1: cptr(char)): cptr(char) = let
-      val c1 = $UN.cptr0_get(p1)
-    in
-      if iseqz(c1) then p1 else loop0(succ(p1))
-    end
-  }
-
-  fun loop1(p1: cptr(char)): bool =
-  (
-    if p1 <= p0 then true else let
-      val p1 = pred(p1)
-      val c1 = $UN.cptr0_get(p1)
-      val test = string0_rforall$test<>(c1)
-    in
-      if test then loop1(p1) else false
-    end
-  )
-
-}
-
 (* ****** ****** *)
-
-
-extern
-fun{}
-str_rightmost2(cs: string, pred: char, pred2: char): (uint, uint)
 
 impltmp{}
 str_rightmost2(cs, ch, ch2) = loop0(p0, 0u, 0u, 0u) where
@@ -161,36 +82,22 @@ str_rightmost2(cs, ch, ch2) = loop0(p0, 0u, 0u, 0u) where
 
 #define CNUL '\000'
 
-extern
-fun{}
-string0_cpy(cs2: string, n: size): string_vt
-
 impltmp{}
 string0_cpy(cs1, size) = let
-  (*
-  val () = println!(size)
-  *)
   val cp0 = $UN.calloc<char>(succ(size))
-
   val cp1 = (string0_ifoldleft<cptr(char)>(cs1, cp0)) where
   {
     impltmp
     string0_ifoldleft$fopr<cptr(char)>(r0, i0, x0) =
-      if
-      $UN.cast{size}i0 < size
-      then ($UN.cptr0_set(r0, x0); succ(r0))
-      else r0
+      ifcase
+      | $UN.cast{size}i0 < size => ($UN.cptr0_set(r0, x0); succ(r0))
+      | _ => r0
   }
 in
-  let
-    val () = $UN.cptr0_set(cp1, CNUL)
-  in
-    $UN.castvwtp0{string0_vt}(cp0)
-  end
+    $UN.castvwtp0{string0_vt}(cp0) where
+      val () = $UN.cptr0_set(cp1, CNUL)
+    end
 end
-
-extern fun{}
-base_ext(xs: string): (string0_vt, string0_vt)
 
 impltmp{}
 base_ext(istr) = (xs, ys) where

--- a/utils/tempacc/DATS/util.dats
+++ b/utils/tempacc/DATS/util.dats
@@ -1,0 +1,212 @@
+(*
+#include "share/HATS/temptory_staload_bucs320.hats"
+*)
+
+
+extern
+fun
+to_bool : int -> bool
+implfun
+to_bool i = (if i = 0 then false else true)
+
+extern
+fun
+to_booln : int -> bool
+implfun
+to_booln i = ~(to_bool i)
+
+
+extern
+fun{}
+str_strr(cs: string, pred: char): int
+
+impltmp{}
+str_strr(cs, ch) = (loop0(cptrof(cs), 0, ~1)) where
+{
+  fun loop0(p1: cptr(char), sz: int, i: int): int = let
+    val c1 = $UN.cptr0_get(p1)
+  in
+    ifcase iseqz(c1) => i
+    | _ =>
+      loop0(succ(p1), sz+1, nxt)
+      where
+        val nxt = (if c1=ch then sz else i)
+      end
+  end
+}
+
+extern
+fun{}
+str_cmp(cs: string, match: string): int
+
+impltmp{}
+str_cmp(cs, match) = loop0(cptrof(cs), cptrof(match)) where
+{
+  fun loop0(p1: cptr(char), p2: cptr(char)): int = let
+    val c1 = $UN.cptr0_get(p1)
+    val c2 = $UN.cptr0_get(p2)
+    (*
+    val () = println!("c1,c2 = ", c1, ",", c2)
+    *)
+  in
+    ifcase iseqz(c1) => (c1 - c2)
+    |_=>
+      ifcase (c1 = c2) => loop0(succ(p1), succ(p2))
+      |_=>
+        char0_ord(c1)
+  end
+}
+
+extern
+fun{}
+ext_cmp(cs: string, match: string): int
+
+impltmp{}
+ext_cmp(cs, match) = let
+  val ext0 = str_strr(cs, '.')
+in
+  ifcase ext0 < 0 (* -1 *)=> ~1
+  | _ => str_cmp(str0, match)
+    where
+      val i = $UN.cast{usize}(ext0)
+      val str0 = $UN.cast{string}(succ(cptrof(cs)+i))
+    end
+end
+
+
+(* ****** ****** *)
+
+extern fun{} dirsep_get ():<> [n:int | n > 0] char(n)
+extern fun{} dirsep_gets ():<> string
+extern fun{} dirname_self ():<> string
+extern fun{} dirname_parent ():<> string
+
+(* ****** ****** *)
+
+extern fun{}
+filename_get_ext(name: string):<> string
+
+extern fun{}
+filename_test_ext(name: string, ext: string):<> bool
+
+(* ****** ****** *)
+
+extern fun{}
+filename_get_base (name: string):<> string
+//vStrptr1
+extern fun{}
+filename_test_base (name: string, base: string):<> bool
+
+impltmp{} dirsep_get () = '/'
+impltmp{} dirsep_gets () = "/"
+impltmp{} dirname_self () = "."
+impltmp{} dirname_parent () = ".."
+
+
+extern fun{} string0_rforall(cs: string): bool
+extern fun{} string0_rforall$test(c0: char): bool
+
+impltmp {} string0_rforall(cs) = (loop1(p1))
+where
+{
+
+  val p0 = string0_cptrof(cs)
+
+  val p1 = loop0(p0) where
+  {
+    fun loop0(p1: cptr(char)): cptr(char) = let
+      val c1 = $UN.cptr0_get(p1)
+    in
+      if iseqz(c1) then p1 else loop0(succ(p1))
+    end
+  }
+
+  fun loop1(p1: cptr(char)): bool =
+  (
+    if p1 <= p0 then true else let
+      val p1 = pred(p1)
+      val c1 = $UN.cptr0_get(p1)
+      val test = string0_rforall$test<>(c1)
+    in
+      if test then loop1(p1) else false
+    end
+  )
+
+}
+
+(* ****** ****** *)
+
+
+extern
+fun{}
+str_rightmost2(cs: string, pred: char, pred2: char): (uint, uint)
+
+impltmp{}
+str_rightmost2(cs, ch, ch2) = loop0(p0, 0u, 0u, 0u) where
+{
+  val p0 = string0_cptrof(cs)
+
+  fun loop0(p1: cptr(char), sz: uint, i: uint, i2: uint): (uint, uint) = let
+    val c1 = $UN.cptr0_get(p1)
+  in
+    ifcase
+    | iseqz(c1) => (i, i2)
+    | _ => loop0(succ(p1), succ(sz), rch1, rch2) where
+    {
+      val rch1 = (if c1 = ch then sz else i)
+      val rch2 = (if c1 = ch2 then sz else i2)
+    }
+  end
+}
+
+#define CNUL '\000'
+
+extern
+fun{}
+string0_cpy(cs2: string, n: size): string_vt
+
+impltmp{}
+string0_cpy(cs1, size) = let
+  (*
+  val () = println!(size)
+  *)
+  val cp0 = $UN.calloc<char>(succ(size))
+
+  val cp1 = (string0_ifoldleft<cptr(char)>(cs1, cp0)) where
+  {
+    impltmp
+    string0_ifoldleft$fopr<cptr(char)>(r0, i0, x0) =
+      if
+      $UN.cast{size}i0 < size
+      then ($UN.cptr0_set(r0, x0); succ(r0))
+      else r0
+  }
+in
+  let
+    val () = $UN.cptr0_set(cp1, CNUL)
+  in
+    $UN.castvwtp0{string0_vt}(cp0)
+  end
+end
+
+extern fun{}
+base_ext(xs: string): (string0_vt, string0_vt)
+
+impltmp{}
+base_ext(istr) = (xs, ys) where
+{
+  val sep = dirsep_get<>()
+
+  val-(fst,snd) = str_rightmost2<>(istr, '/', '.')
+
+  val split0 = $UN.cast{size}(snd - fst - 1u)
+
+  val str0 = $UN.cast{string}(succ(cptrof(istr)+fst))
+  val str1 = $UN.cast{string}(succ(cptrof(str0)+split0))
+
+  val length = i2sz(length(str0))
+  val split1 = length - $UN.cast{size}(split0)
+
+  val xs = string0_cpy<>(str0, split0)
+  val ys = string0_cpy<>(str1, split1)
+}

--- a/utils/tempacc/Makefile_build
+++ b/utils/tempacc/Makefile_build
@@ -9,15 +9,15 @@ CFLAGS=-std=c99 -D_XOPEN_SOURCE
 #
 ######
 
-PATSHOMEQ="$(PATSHOME)"
+TEMPTORYQ=$(TEMPTORY)
 
 ######
 
-PATSOPT=$(PATSHOMEQ)/bin/patsopt
+TEMPOPT=$(TEMPTORYQ)/bin/tempopt
 
 ######
 
-INCLUDE=-I$(PATSHOMEQ) -I$(PATSHOMEQ)/ccomp/runtime
+INCLUDE=-I$(TEMPTORYQ) -I$(TEMPTORYQ)/ccomp/runtime
 
 ######
 
@@ -34,7 +34,7 @@ tempacc: \
 #
 ######
 
-%_dats.c: %.dats; $(PATSOPT) --output $@ --dynamic $<
+%_dats.c: %.dats; $(TEMPOPT) --output $@ --dynamic $<
 
 ######
 

--- a/utils/tempacc/SATS/atscc.sats
+++ b/utils/tempacc/SATS/atscc.sats
@@ -13,12 +13,12 @@
 ** the terms of  the GNU GENERAL PUBLIC LICENSE (GPL) as published by the
 ** Free Software Foundation; either version 3, or (at  your  option)  any
 ** later version.
-** 
+**
 ** ATS is distributed in the hope that it will be useful, but WITHOUT ANY
 ** WARRANTY; without  even  the  implied  warranty  of MERCHANTABILITY or
 ** FITNESS FOR A PARTICULAR PURPOSE.  See the  GNU General Public License
 ** for more details.
-** 
+**
 ** You  should  have  received  a  copy of the GNU General Public License
 ** along  with  ATS;  see the  file COPYING.  If not, please write to the
 ** Free Software Foundation,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -33,10 +33,14 @@
 
 (* ****** ****** *)
 
+#include "share/HATS/temptory_staload_bucs320.hats"
+
+vtypedef stringlst_vt = list0_vt(string)
+
 datatype commarg =
 //
   | CAhats of () // -hats: patsopt --help
-  | CAvats of () // -vats: patsopt --version 
+  | CAvats of () // -vats: patsopt --version
 //
   | CAccats of () // -ccats: compilation only
   | CAtcats of () // -tcats: typechecking only
@@ -63,19 +67,27 @@ datatype commarg =
 (* ****** ****** *)
 //
 typedef
-commarglst = List0(commarg)
+commarglst = list0(commarg)
 vtypedef
-commarglst_vt = List0_vt(commarg)
+commarglst_vt = list0_vt(commarg)
 //
 (* ****** ****** *)
 //
+(*
 fun
 fprint_commarg(out: FILEref, ca: commarg): void
+*)
+fun
+print_commarg(ca: commarg): void
+(*
 fun
 fprint_commarglst(out: FILEref, cas: commarglst): void
+*)
+fun
+print_commarglst(cas: commarglst): void
 //
-overload fprint with fprint_commarg of 0
-overload fprint with fprint_commarglst of 10
+#symload print with print_commarg of 0
+#symload print with print_commarglst of 10
 //
 (* ****** ****** *)
 //
@@ -117,10 +129,10 @@ fprint_atsccompline(out: FILEref, cas: commarglst): void
 //
 fun
 atsoptline_make
-  (cas: !RD(commarglst), ca0: commarg): stringlst_vt
+  (cas: (* !RD *)(commarglst), ca0: commarg): stringlst_vt
 //
 fun
-atsoptline_make_all(cas: commarglst): List0_vt(stringlst_vt)
+atsoptline_make_all(cas: commarglst): list0_vt(stringlst_vt)
 //
 (* ****** ****** *)
 
@@ -135,7 +147,7 @@ atsoptline_exec
 fun
 atsoptline_exec_all
 ( flag: int
-, atsopt: string, args: List_vt (stringlst_vt)): int(*status*)
+, atsopt: string, args: list0_vt (stringlst_vt)): int(*status*)
 //
 (* ****** ****** *)
 //

--- a/utils/tempacc/SATS/util.sats
+++ b/utils/tempacc/SATS/util.sats
@@ -1,0 +1,53 @@
+fun{}
+to_bool : int -> bool
+
+fun{}
+to_booln : int -> bool
+
+fun{}
+str_strr(cs: string, pred: char): int
+
+fun{}
+str_cmp(cs: string, match: string): int
+
+fun{}
+ext_cmp(cs: string, match: string): int
+
+(* ****** ****** *)
+
+fun{}
+dirsep_get ():<> [n:int | n > 0] char(n)
+
+fun{}
+dirsep_gets ():<> string
+
+fun{}
+dirname_self ():<> string
+
+fun{}
+dirname_parent ():<> string
+
+(* ****** ****** *)
+
+fun{}
+filename_get_ext(name: string):<> string
+
+fun{}
+filename_test_ext(name: string, ext: string):<> bool
+
+fun{}
+filename_get_base (name: string):<> string
+
+fun{}
+filename_test_base (name: string, base: string):<> bool
+
+(* ****** ****** *)
+
+fun{}
+str_rightmost2(cs: string, pred: char, pred2: char): (uint, uint)
+
+fun{}
+string0_cpy(cs2: string, n: size): string_vt
+
+fun{}
+base_ext(xs: string): (string0_vt, string0_vt)


### PR DESCRIPTION
Converting tempacc for compilation by tempopt instead of patsopt. 

Open to suggestions/changes/improvements -- primarily with respect to unsafe string operations